### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 AivisSpeech用のModel Context Protocol (MCP) サーバーの実装です。このサーバーは、AivisSpeech Engineと連携して、音声合成のためのインターフェースを提供します。MCPプロトコルを通じて、AIアシスタントなどのアプリケーションからAivisSpeechの音声合成機能を簡単に利用できるようになります。
 
+<a href="https://glama.ai/mcp/servers/@kentaro/aivis-speech-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kentaro/aivis-speech-mcp/badge" alt="AivisSpeech Server MCP server" />
+</a>
+
 ## 概要
 
 AivisSpeech MCP サーバーは以下の機能を提供します：


### PR DESCRIPTION
This PR adds a badge for the [AivisSpeech MCP Server](https://glama.ai/mcp/servers/@kentaro/aivis-speech-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kentaro/aivis-speech-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kentaro/aivis-speech-mcp/badge" alt="AivisSpeech Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.